### PR TITLE
feedbackを反映：フィルタ保存・キャラ表示改善・ダークモード・プロフィール表示を追加

### DIFF
--- a/tools/sf6-buckler-export/analysis/analysis_report_dynamic.html
+++ b/tools/sf6-buckler-export/analysis/analysis_report_dynamic.html
@@ -24,6 +24,27 @@
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             padding: 20px;
             color: #333;
+            transition: background 0.2s, color 0.2s;
+        }
+
+        body.dark-mode {
+            background: linear-gradient(135deg, #1c1f2b 0%, #11131a 100%);
+            color: #f1f3f5;
+        }
+
+        body.dark-mode .container {
+            background: #1f2430;
+        }
+
+        body.dark-mode .chart-container,
+        body.dark-mode .table-container,
+        body.dark-mode #filterMenuContent {
+            background: #2b3140 !important;
+            color: #f1f3f5;
+        }
+
+        body.dark-mode td {
+            border-bottom-color: #495057;
         }
 
         .container {
@@ -213,7 +234,10 @@
         <h1 id="pageTitle" style="display: flex; align-items: center; justify-content: center; gap: 15px;">🎮 SF6 Battle
             Analysis Report</h1>
 
-        <button class="reload-btn" onclick="loadAndAnalyze()">🔄 データを再読み込み</button>
+        <div style="display:flex; gap:12px; justify-content:center; margin-bottom:20px;">
+        <button class="reload-btn" style="margin:0;" onclick="loadAndAnalyze()">🔄 データを再読み込み</button>
+        <button class="reload-btn" style="margin:0; background: linear-gradient(135deg, #495057 0%, #212529 100%);" onclick="toggleDarkMode()">🌙 ダークモード切替</button>
+        </div>
 
         <div id="content">
             <div class="loading">📊 データを読み込み中...</div>
@@ -223,6 +247,13 @@
     <script>
         let charts = {};
         let allBattles = []; // 全データ保持（正規化済み）
+        const FILTER_STATE_KEY = 'analysisFilterState';
+        const CHAR_NAME_MAP = {
+            aki: 'A.K.I.',
+            chunli: 'Chun-Li',
+            cviper: 'C.Viper',
+            honda: 'E.Honda'
+        };
         let state = {
             maxBattles: null, // null = 全件
             myCharFilter: null, // null = 全キャラ
@@ -232,6 +263,49 @@
 
         // キャラクター表示順（localStorageから読み込み、なければ空配列）
         let customCharOrder = JSON.parse(localStorage.getItem('customCharOrder') || '[]');
+
+        function getFormalCharacterName(char) {
+            if (!char) return '-';
+            return CHAR_NAME_MAP[char] || char.toUpperCase();
+        }
+
+        function renderCharacterMiniBadge(char) {
+            if (!char || char === '-') return '-';
+            const icon = char.toUpperCase();
+            const name = getFormalCharacterName(char);
+            return `<div style="display: inline-flex; flex-direction: column; align-items: center; gap: 4px; min-width: 68px;">
+                <img src="../src/icon/${icon}.png" alt="${char}" style="width: 44px; height: 44px; object-fit: contain;" onerror="this.style.display='none'; this.nextElementSibling.style.display='inline';">
+                <span style="display: none; font-size: 0.75em;">${name}</span>
+                <span style="font-size: 0.72em; color: #444; font-weight: 600; line-height: 1; text-align: center;">${name}</span>
+            </div>`;
+        }
+
+        function loadFilterState() {
+            try {
+                const saved = JSON.parse(localStorage.getItem(FILTER_STATE_KEY) || '{}');
+                state.maxBattles = saved.maxBattles || null;
+                state.myCharFilter = saved.myCharFilter || null;
+                state.matchTypeFilter = saved.matchTypeFilter || null;
+                state.minMatchCount = saved.minMatchCount || 1;
+            } catch (e) {
+                console.warn('フィルタ状態の復元に失敗:', e);
+            }
+        }
+
+        function saveFilterState() {
+            localStorage.setItem(FILTER_STATE_KEY, JSON.stringify(state));
+        }
+
+        function toggleDarkMode() {
+            document.body.classList.toggle('dark-mode');
+            localStorage.setItem('analysisDarkMode', document.body.classList.contains('dark-mode') ? '1' : '0');
+        }
+
+        if (localStorage.getItem('analysisDarkMode') === '1') {
+            document.body.classList.add('dark-mode');
+        }
+
+        loadFilterState();
 
         // Elo式の定数とキャラ補正値（データ分析により最適化）
         const ELO_K_VALUE = 340;
@@ -471,7 +545,7 @@
                             <div style="display: flex; flex-wrap: wrap; gap: 10px;">
                                 <button class="filter-btn char-btn" data-type="myChar" data-value="" onclick="selectFilter('myChar', '')">全キャラ</button>
                                 ${myChars.map(c => `
-                                    <button class="filter-btn char-btn" data-type="myChar" data-value="${c}" onclick="selectFilter('myChar', '${c}')">${c}</button>
+                                    <button class="filter-btn char-btn" data-type="myChar" data-value="${c}" onclick="selectFilter('myChar', '${c}')">${renderCharacterMiniBadge(c)}</button>
                                 `).join('')}
                             </div>
                         </div>
@@ -519,8 +593,9 @@
                         box-shadow: 0 4px 10px rgba(102, 126, 234, 0.3);
                     }
                     .char-btn {
-                        min-width: 100px;
+                        min-width: 84px;
                         font-weight: bold;
+                        padding: 8px 10px;
                     }
                     @keyframes slideUp {
                         from {
@@ -549,6 +624,8 @@
             reloadBtn.insertAdjacentHTML('afterend', filterHTML);
 
             // 初期状態を反映
+            document.getElementById('filterMatchType').value = state.matchTypeFilter || '';
+            document.getElementById('filterMinMatch').value = state.minMatchCount || 1;
             updateFilterButtonStates();
 
             // スクロールオブザーバーを再設定
@@ -564,6 +641,7 @@
             }
 
             updateFilterButtonStates();
+            saveFilterState();
             updateFilters();
         }
 
@@ -762,6 +840,7 @@
             state.matchTypeFilter = matchType || null;
             state.minMatchCount = minMatch;
 
+            saveFilterState();
             analyzeAndRender();
         }
 
@@ -776,6 +855,7 @@
             state.minMatchCount = 1;
 
             updateFilterButtonStates();
+            saveFilterState();
             analyzeAndRender();
         }
 
@@ -1086,13 +1166,18 @@
             // 8. 連敗数の計算
             let currentLoseStreak = 0;
             let maxLoseStreak = 0;
+            let currentWinStreak = 0;
+            let maxWinStreak = 0;
             battles.forEach(b => {
                 const result = normalizeResult(b.result);
                 if (result === 'LOSE') {
                     currentLoseStreak++;
+                    currentWinStreak = 0;
                     maxLoseStreak = Math.max(maxLoseStreak, currentLoseStreak);
                 } else if (result === 'WIN') {
+                    currentWinStreak++;
                     currentLoseStreak = 0;
+                    maxWinStreak = Math.max(maxWinStreak, currentWinStreak);
                 }
             });
 
@@ -1461,6 +1546,13 @@
                     : '0.0'
             };
 
+
+            const latestBattle = battles[0] || allBattles[0] || {};
+            const profile = {
+                userCode: latestBattle.user_code || latestBattle.usercode || latestBattle.code || '-',
+                playerName: latestBattle.player_name || latestBattle.user_name || latestBattle.name || '-'
+            };
+
             // HTML生成
             renderHTML({
                 totalBattles, wins, losses, draws, unknown, winRate,
@@ -1469,13 +1561,13 @@
                 charWinRates, oppWinRates,
                 winMethods, loseMethods,
                 mrData, mrStats, mrDiffData, avgMrDiff,
-                maxLoseStreak, avgExpectedWinRate, overPerformance,
+                maxLoseStreak, maxWinStreak, avgExpectedWinRate, overPerformance,
                 charExpectedList, mrRangeExpectedList,
                 firstRoundWinRate, firstRoundWinnerMatches,
                 comebackRate, down01Situations,
                 oneOneWinRate, oneOneSituations,
                 sessionStats, avgFatigueData, sortedMrBands,
-                parseErrors, parseErrorRows, detailData,
+                parseErrors, parseErrorRows, detailData, profile,
                 isMyCharFiltered: state.myCharFilter !== null
             });
         }
@@ -1491,6 +1583,7 @@
 
             const html = `
         ${charBadge}
+        <div style="text-align: center; margin: 0 0 20px; color: #555; font-weight: 600;">👤 ユーザーコード: ${data.profile.userCode} / 名前: ${data.profile.playerName}</div>
         <!-- 1段目: 5枚 -->
         <div style="display: grid; grid-template-columns: repeat(5, 1fr); gap: 20px; margin-bottom: 20px;">
           <div class="stat-card">
@@ -1510,19 +1603,19 @@
           </div>
           <div class="stat-card">
             <div class="stat-label tooltip-container">
-              最大連敗数
-              <span class="tooltip-text">連続敗北記録。メンタルの乱れや調子の悪化を示す指標。連敗時は休憩を取るのが効果的。</span>
+              連勝 / 連敗
+              <span class="tooltip-text">最大連勝と最大連敗をセット表示。勢いと崩れやすい局面を一目で把握できます。</span>
             </div>
-            <div class="stat-value">${data.maxLoseStreak}</div>
-            <small style="opacity: 0.8;">連続敗北記録</small>
+            <div class="stat-value" style="font-size: 2em;">${data.maxWinStreak} / ${data.maxLoseStreak}</div>
+            <small style="opacity: 0.8;">最大連勝 / 最大連敗</small>
           </div>
           <div class="stat-card">
             <div class="stat-label tooltip-container">
-              平均MR差
+              平均対戦MR差
               <span class="tooltip-text">相手MR - 自分MRの平均。プラスなら格上相手と対戦、マイナスなら格下相手。期待勝率と組み合わせて実力の伸びを判断します。</span>
             </div>
             <div class="stat-value">${data.avgMrDiff >= 0 ? '+' : ''}${data.avgMrDiff}</div>
-            <small style="opacity: 0.8;">相手MR - 自分MR</small>
+            <small style="opacity: 0.8;">(相手MR - 自分MR)の平均</small>
           </div>
           <div class="stat-card">
             <div class="stat-label tooltip-container">
@@ -1621,7 +1714,7 @@
             <tbody>
               ${data.charExpectedList.map(c => `
                 <tr>
-                  <td><strong>${c.character}</strong></td>
+                  <td>${renderCharacterMiniBadge(c.character)}</td>
                   <td>${c.expected}%</td>
                   <td><strong>${c.actual}%</strong></td>
                   <td style="color: ${parseFloat(c.diff) >= 0 ? 'green' : 'red'}; font-weight: bold;">
@@ -1933,8 +2026,8 @@
                   <tr>
                     <td>${row.index}</td>
                     <td>${row.timestamp}</td>
-                    <td>${row.my_char}</td>
-                    <td>${row.opp_char}</td>
+                    <td>${renderCharacterMiniBadge(row.my_char)}</td>
+                    <td>${renderCharacterMiniBadge(row.opp_char)}</td>
                     <td><code>${row.round_score}</code></td>
                   </tr>
                 `).join('')}
@@ -1969,9 +2062,9 @@
                   <tr style="${!d.round_score_ok ? 'background: #fff3cd;' : ''}">
                     <td>${d.index}</td>
                     <td style="font-size: 0.8em;">${d.battle_time}</td>
-                    <td><strong>${d.my_char}</strong></td>
+                    <td>${renderCharacterMiniBadge(d.my_char)}</td>
                     <td>${d.my_mr}</td>
-                    <td><strong>${d.opp_char}</strong></td>
+                    <td>${renderCharacterMiniBadge(d.opp_char)}</td>
                     <td>${d.opp_mr}</td>
                     <td style="color: ${d.result === 'WIN' ? 'green' : d.result === 'LOSE' ? 'red' : 'gray'};">
                       <strong>${d.result}</strong>


### PR DESCRIPTION
### Motivation
- feedbackフォルダの要望に従い、分析画面で「前回のフィルタ設定を復元したい」「キャラ名をアイコンで見たい」「ダークモードがほしい」「ユーザー情報を見たい」といったUX改善を反映するための変更です。 

### Description
- フィルタの保存/復元を `localStorage` のキー `analysisFilterState` で実装し、`loadFilterState()` / `saveFilterState()` を追加してフィルタ（試合数・自キャラ・種別・最小対戦数）を永続化しました。 
- キャラクター表示をミニアイコン＋正式名にする `CHAR_NAME_MAP` と `renderCharacterMiniBadge()` を追加し、フィルタボタン・期待勝率表・詳細テーブル等でアイコン表示に置換しました。 
- ダークモード切替ボタンを画面上部に追加し、状態を `localStorage` (`analysisDarkMode`) に保存して復元する `toggleDarkMode()` を実装しました。 
- ユーザーコード／表示名を上部に表示するプロファイル抽出を追加し、最大連敗のみの表示を「最大連勝 / 最大連敗」表示へ変更するために連勝数集計（`maxWinStreak`）を追加、`平均MR差`ラベルを`平均対戦MR差`に変更しました。 

### Testing
- `git diff --check` を実行して差分のフォーマット問題がないことを確認しました（成功）。
- ローカルで `python -m http.server 8000` を起動して動作確認を行い、ページが正常に読み込まれることを確認しました（成功）。
- Playwright を使って `http://127.0.0.1:8000/analysis_report_dynamic.html` を開き、レンダリング後のスクリーンショットを取得してUI変更（フィルタ・アイコン・ダークモードボタン・プロフィール表示など）を確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da925a3d8832d920b28202ac1a2de)