### PR TITLE
レビュー指摘対応: ダークモード可視化とミニアイコン表示を修正

### DIFF
--- a/tools/sf6-buckler-export/analysis/analysis_report_dynamic.html
+++ b/tools/sf6-buckler-export/analysis/analysis_report_dynamic.html
@@ -24,6 +24,29 @@
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             padding: 20px;
             color: #333;
+            --profile-color: #333;
+            transition: background 0.2s, color 0.2s;
+        }
+
+        body.dark-mode {
+            background: linear-gradient(135deg, #1c1f2b 0%, #11131a 100%);
+            color: #f1f3f5;
+            --profile-color: #f1f3f5;
+        }
+
+        body.dark-mode .container {
+            background: #1f2430;
+        }
+
+        body.dark-mode .chart-container,
+        body.dark-mode .table-container,
+        body.dark-mode #filterMenuContent {
+            background: #2b3140 !important;
+            color: #f1f3f5;
+        }
+
+        body.dark-mode td {
+            border-bottom-color: #495057;
         }
 
         .container {
@@ -213,7 +236,10 @@
         <h1 id="pageTitle" style="display: flex; align-items: center; justify-content: center; gap: 15px;">🎮 SF6 Battle
             Analysis Report</h1>
 
-        <button class="reload-btn" onclick="loadAndAnalyze()">🔄 データを再読み込み</button>
+        <div style="display:flex; gap:12px; justify-content:center; margin-bottom:20px;">
+        <button class="reload-btn" style="margin:0;" onclick="loadAndAnalyze()">🔄 データを再読み込み</button>
+        <button id="darkModeToggleBtn" class="reload-btn" style="margin:0; background: linear-gradient(135deg, #495057 0%, #212529 100%);" onclick="toggleDarkMode()">🌙 ダークモード切替</button>
+        </div>
 
         <div id="content">
             <div class="loading">📊 データを読み込み中...</div>
@@ -223,6 +249,19 @@
     <script>
         let charts = {};
         let allBattles = []; // 全データ保持（正規化済み）
+        const FILTER_STATE_KEY = 'analysisFilterState';
+        const CHAR_NAME_MAP = {
+            aki: 'A.K.I.', blanka: 'Blanka', cammy: 'Cammy', chunli: 'Chun-Li', cviper: 'C.Viper',
+            deejay: 'Dee Jay', dhalsim: 'Dhalsim', ed: 'Ed', elena: 'Elena', gouki: 'Gouki',
+            guile: 'Guile', honda: 'E.Honda', jamie: 'Jamie', jp: 'JP', juri: 'Juri', ken: 'Ken',
+            kimberly: 'Kimberly', lily: 'Lily', luke: 'Luke', mai: 'Mai', manon: 'Manon',
+            marisa: 'Marisa', rashid: 'Rashid', ryu: 'Ryu', sagat: 'Sagat', terry: 'Terry',
+            vega: 'Vega', zangief: 'Zangief'
+        };
+        const ICON_FILE_MAP = {
+            cviper: 'cviper',
+            sagat: 'sagat'
+        };
         let state = {
             maxBattles: null, // null = 全件
             myCharFilter: null, // null = 全キャラ
@@ -232,6 +271,58 @@
 
         // キャラクター表示順（localStorageから読み込み、なければ空配列）
         let customCharOrder = JSON.parse(localStorage.getItem('customCharOrder') || '[]');
+
+        function getFormalCharacterName(char) {
+            if (!char) return '-';
+            return CHAR_NAME_MAP[char] || char;
+        }
+
+        function renderCharacterMiniBadge(char) {
+            if (!char || char === '-') return '-';
+            const icon = (ICON_FILE_MAP[char] || char.toUpperCase());
+            const name = getFormalCharacterName(char);
+            return `<div style="display: inline-flex; flex-direction: column; align-items: center; gap: 4px; min-width: 68px;">
+                <img src="../src/icon/${icon}.png" alt="${char}" style="width: 44px; height: 44px; object-fit: contain;" onerror="this.style.display='none'; this.nextElementSibling.style.display='inline';">
+                <span style="display: none; font-size: 0.75em;">${name}</span>
+                <span style="font-size: 0.72em; color: #444; font-weight: 600; line-height: 1; text-align: center;">${name}</span>
+            </div>`;
+        }
+
+        function loadFilterState() {
+            try {
+                const saved = JSON.parse(localStorage.getItem(FILTER_STATE_KEY) || '{}');
+                state.maxBattles = saved.maxBattles || null;
+                state.myCharFilter = saved.myCharFilter || null;
+                state.matchTypeFilter = saved.matchTypeFilter || null;
+                state.minMatchCount = saved.minMatchCount || 1;
+            } catch (e) {
+                console.warn('フィルタ状態の復元に失敗:', e);
+            }
+        }
+
+        function saveFilterState() {
+            localStorage.setItem(FILTER_STATE_KEY, JSON.stringify(state));
+        }
+
+
+        function updateDarkModeButtonLabel() {
+            const btn = document.getElementById('darkModeToggleBtn');
+            if (!btn) return;
+            btn.textContent = document.body.classList.contains('dark-mode') ? '☀️ ライトモード切替' : '🌙 ダークモード切替';
+        }
+
+        function toggleDarkMode() {
+            document.body.classList.toggle('dark-mode');
+            localStorage.setItem('analysisDarkMode', document.body.classList.contains('dark-mode') ? '1' : '0');
+            updateDarkModeButtonLabel();
+        }
+
+        if (localStorage.getItem('analysisDarkMode') === '1') {
+            document.body.classList.add('dark-mode');
+        }
+
+        updateDarkModeButtonLabel();
+        loadFilterState();
 
         // Elo式の定数とキャラ補正値（データ分析により最適化）
         const ELO_K_VALUE = 340;
@@ -471,7 +562,7 @@
                             <div style="display: flex; flex-wrap: wrap; gap: 10px;">
                                 <button class="filter-btn char-btn" data-type="myChar" data-value="" onclick="selectFilter('myChar', '')">全キャラ</button>
                                 ${myChars.map(c => `
-                                    <button class="filter-btn char-btn" data-type="myChar" data-value="${c}" onclick="selectFilter('myChar', '${c}')">${c}</button>
+                                    <button class="filter-btn char-btn" data-type="myChar" data-value="${c}" onclick="selectFilter('myChar', '${c}')">${renderCharacterMiniBadge(c)}</button>
                                 `).join('')}
                             </div>
                         </div>
@@ -519,8 +610,9 @@
                         box-shadow: 0 4px 10px rgba(102, 126, 234, 0.3);
                     }
                     .char-btn {
-                        min-width: 100px;
+                        min-width: 84px;
                         font-weight: bold;
+                        padding: 8px 10px;
                     }
                     @keyframes slideUp {
                         from {
@@ -549,6 +641,8 @@
             reloadBtn.insertAdjacentHTML('afterend', filterHTML);
 
             // 初期状態を反映
+            document.getElementById('filterMatchType').value = state.matchTypeFilter || '';
+            document.getElementById('filterMinMatch').value = state.minMatchCount || 1;
             updateFilterButtonStates();
 
             // スクロールオブザーバーを再設定
@@ -564,6 +658,7 @@
             }
 
             updateFilterButtonStates();
+            saveFilterState();
             updateFilters();
         }
 
@@ -762,6 +857,7 @@
             state.matchTypeFilter = matchType || null;
             state.minMatchCount = minMatch;
 
+            saveFilterState();
             analyzeAndRender();
         }
 
@@ -776,6 +872,7 @@
             state.minMatchCount = 1;
 
             updateFilterButtonStates();
+            saveFilterState();
             analyzeAndRender();
         }
 
@@ -1086,13 +1183,18 @@
             // 8. 連敗数の計算
             let currentLoseStreak = 0;
             let maxLoseStreak = 0;
+            let currentWinStreak = 0;
+            let maxWinStreak = 0;
             battles.forEach(b => {
                 const result = normalizeResult(b.result);
                 if (result === 'LOSE') {
                     currentLoseStreak++;
+                    currentWinStreak = 0;
                     maxLoseStreak = Math.max(maxLoseStreak, currentLoseStreak);
                 } else if (result === 'WIN') {
+                    currentWinStreak++;
                     currentLoseStreak = 0;
+                    maxWinStreak = Math.max(maxWinStreak, currentWinStreak);
                 }
             });
 
@@ -1461,6 +1563,13 @@
                     : '0.0'
             };
 
+
+            const latestBattle = battles[0] || allBattles[0] || {};
+            const profile = {
+                userCode: latestBattle.user_code || latestBattle.usercode || latestBattle.short_id || latestBattle.fighter_id || latestBattle.code || '-',
+                playerName: latestBattle.player_name || latestBattle.user_name || latestBattle.nickname || latestBattle.player || latestBattle.name || '-'
+            };
+
             // HTML生成
             renderHTML({
                 totalBattles, wins, losses, draws, unknown, winRate,
@@ -1469,13 +1578,13 @@
                 charWinRates, oppWinRates,
                 winMethods, loseMethods,
                 mrData, mrStats, mrDiffData, avgMrDiff,
-                maxLoseStreak, avgExpectedWinRate, overPerformance,
+                maxLoseStreak, maxWinStreak, avgExpectedWinRate, overPerformance,
                 charExpectedList, mrRangeExpectedList,
                 firstRoundWinRate, firstRoundWinnerMatches,
                 comebackRate, down01Situations,
                 oneOneWinRate, oneOneSituations,
                 sessionStats, avgFatigueData, sortedMrBands,
-                parseErrors, parseErrorRows, detailData,
+                parseErrors, parseErrorRows, detailData, profile,
                 isMyCharFiltered: state.myCharFilter !== null
             });
         }
@@ -1483,7 +1592,7 @@
         // HTML描画
         function renderHTML(data) {
             // キャラ名表示を作成（アイコン画像を表示）
-            const charIcon = state.myCharFilter ? state.myCharFilter : 'ALL';
+            const charIcon = state.myCharFilter ? (ICON_FILE_MAP[state.myCharFilter] || state.myCharFilter.toUpperCase()) : 'ALL';
             const charBadge = `<div style="text-align: center; margin: 20px 0; padding: 15px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); border-radius: 12px; box-shadow: 0 4px 15px rgba(102, 126, 234, 0.3);">
                      <img src="../src/icon/${charIcon}.png" alt="${charIcon}" style="height: 80px; object-fit: contain;" onerror="this.style.display='none'; this.nextElementSibling.style.display='inline';">
                      <span style="color: white; font-size: 2em; font-weight: bold; display: none;">${charIcon}</span>
@@ -1491,6 +1600,7 @@
 
             const html = `
         ${charBadge}
+        <div style="text-align: center; margin: 0 0 20px; color: var(--profile-color, #333); font-weight: 700; font-size: 1.05em;">👤 ユーザーコード: ${data.profile.userCode} / 名前: ${data.profile.playerName}</div>
         <!-- 1段目: 5枚 -->
         <div style="display: grid; grid-template-columns: repeat(5, 1fr); gap: 20px; margin-bottom: 20px;">
           <div class="stat-card">
@@ -1510,19 +1620,19 @@
           </div>
           <div class="stat-card">
             <div class="stat-label tooltip-container">
-              最大連敗数
-              <span class="tooltip-text">連続敗北記録。メンタルの乱れや調子の悪化を示す指標。連敗時は休憩を取るのが効果的。</span>
+              連勝 / 連敗
+              <span class="tooltip-text">最大連勝と最大連敗をセット表示。勢いと崩れやすい局面を一目で把握できます。</span>
             </div>
-            <div class="stat-value">${data.maxLoseStreak}</div>
-            <small style="opacity: 0.8;">連続敗北記録</small>
+            <div class="stat-value" style="font-size: 2em;">${data.maxWinStreak} / ${data.maxLoseStreak}</div>
+            <small style="opacity: 0.8;">最大連勝 / 最大連敗</small>
           </div>
           <div class="stat-card">
             <div class="stat-label tooltip-container">
-              平均MR差
+              平均対戦MR差
               <span class="tooltip-text">相手MR - 自分MRの平均。プラスなら格上相手と対戦、マイナスなら格下相手。期待勝率と組み合わせて実力の伸びを判断します。</span>
             </div>
             <div class="stat-value">${data.avgMrDiff >= 0 ? '+' : ''}${data.avgMrDiff}</div>
-            <small style="opacity: 0.8;">相手MR - 自分MR</small>
+            <small style="opacity: 0.8;">(相手MR - 自分MR)の平均</small>
           </div>
           <div class="stat-card">
             <div class="stat-label tooltip-container">
@@ -1621,7 +1731,7 @@
             <tbody>
               ${data.charExpectedList.map(c => `
                 <tr>
-                  <td><strong>${c.character}</strong></td>
+                  <td>${renderCharacterMiniBadge(c.character)}</td>
                   <td>${c.expected}%</td>
                   <td><strong>${c.actual}%</strong></td>
                   <td style="color: ${parseFloat(c.diff) >= 0 ? 'green' : 'red'}; font-weight: bold;">
@@ -1933,8 +2043,8 @@
                   <tr>
                     <td>${row.index}</td>
                     <td>${row.timestamp}</td>
-                    <td>${row.my_char}</td>
-                    <td>${row.opp_char}</td>
+                    <td>${renderCharacterMiniBadge(row.my_char)}</td>
+                    <td>${renderCharacterMiniBadge(row.opp_char)}</td>
                     <td><code>${row.round_score}</code></td>
                   </tr>
                 `).join('')}
@@ -1969,9 +2079,9 @@
                   <tr style="${!d.round_score_ok ? 'background: #fff3cd;' : ''}">
                     <td>${d.index}</td>
                     <td style="font-size: 0.8em;">${d.battle_time}</td>
-                    <td><strong>${d.my_char}</strong></td>
+                    <td>${renderCharacterMiniBadge(d.my_char)}</td>
                     <td>${d.my_mr}</td>
-                    <td><strong>${d.opp_char}</strong></td>
+                    <td>${renderCharacterMiniBadge(d.opp_char)}</td>
                     <td>${d.opp_mr}</td>
                     <td style="color: ${d.result === 'WIN' ? 'green' : d.result === 'LOSE' ? 'red' : 'gray'};">
                       <strong>${d.result}</strong>


### PR DESCRIPTION
### Motivation
- ダークモード切替ボタンやミニアイコン＋正式名表示が画面上で認識できない問題を解消するための修正です。 
- アイコンファイル名の大小文字差やプロフィール表示の視認性を改善してUXを向上させる意図です。 
- KPI表記の誤解を招くラベル（平均MR差等）や連勝/連敗の表示要望に対応するためです。

### Description
- UI/CSS: ダークモード用のスタイルを追加しプロフィール色を `--profile-color` にして `body.dark-mode` 時にも視認できるように調整しました。 
- ダークモード制御: トグルボタンに `id="darkModeToggleBtn"` を付与し、`toggleDarkMode()` と `updateDarkModeButtonLabel()` を追加して表示文言を `🌙 ダークモード切替` / `☀️ ライトモード切替` に切替するようにしました。 
- キャラ表示: `CHAR_NAME_MAP` を全キャラ分に拡張し `ICON_FILE_MAP` を追加して小文字ファイル名（例:`cviper.png`/`sagat.png`）に対応し、`renderCharacterMiniBadge()` を導入してフィルタボタン・期待勝率表・詳細テーブル等でミニアイコン＋正式名を表示するようにしました。 
- フィルタ状態/プロフィール/KPI: フィルタの永続化キー `analysisFilterState` の `loadFilterState()` / `saveFilterState()` を呼び出すようにし、`maxWinStreak` を追加してKPIカードを `連勝 / 連敗` 表示に変更し、`平均MR差` を `平均対戦MR差` にラベル修正しました。 

### Testing
- フォーマットチェックで `git diff --check` を実行して問題がないことを確認しました（成功）。 
- ローカルで `python -m http.server` を起動して `analysis_report_dynamic.html` を配信しページが返ることを確認しました（成功）。 
- Playwright を使って `http://127.0.0.1:8001/tools/sf6-buckler-export/analysis/analysis_report_dynamic.html` を開き、ライト/ダーク切替ボタンの操作とスクリーンショット取得で表示（ボタン文言、ダークスタイル、ミニアイコン、プロフィール、KPI表記）が期待通りであることを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da925a3d8832d920b28202ac1a2de)